### PR TITLE
Adjust colors for `yellow`, `green`, and `blue`

### DIFF
--- a/theme.js
+++ b/theme.js
@@ -6,7 +6,7 @@ const spacing = [
   90, 95, 96, 100
 ];
 
-// https://uicolors.app/edit?sv1=primary:50-ecebff/100-dedbff/200-c7c2ff/300-a899ff/400-937aff/500-7e61ff/600-6a4ce1/700-5b33c7/800-3e238b/900-251452/950-11082b;slate:50-f4f4fb/100-e7e7f4/200-d9d9ed/300-c4c4e3/400-aeaed6/500-9692c4/600-8178b0/700-655b95/800-4b4276/900-332b5a/950-1d1641;blue:50-f0f8fe/100-deeefb/200-c4e3f9/300-9cd1f4/400-6db6ed/500-549ee7/600-367dda/700-2d69c8/800-2b56a2/900-274a81/950-1c2e4f;yellow:50-fff9eb/100-ffefc6/200-ffdc88/300-ffcb60/400-ffac20/500-f98907/600-dd6302/700-b74306/800-94320c/900-7a2b0d/950-461402;red:50-fff1f3/100-ffe3e6/200-ffccd4/300-ffa1b1/400-ff708a/500-f93a63/600-e7174e/700-c30d41/800-a30e3d/900-8b103b/950-4e031b
+// https://uicolors.app/edit?sv1=primary:50-ecebff/100-dedbff/200-c7c2ff/300-a899ff/400-937aff/500-7e61ff/600-6a4ce1/700-5b33c7/800-3e238b/900-251452/950-11082b;slate:50-f4f4fb/100-e7e7f4/200-d9d9ed/300-c4c4e3/400-aeaed6/500-9692c4/600-8178b0/700-655b95/800-4b4276/900-332b5a/950-1d1641;red:50-fff1f3/100-ffe3e6/200-ffccd4/300-ffa1b1/400-ff708a/500-f93a63/600-e7174e/700-c30d41/800-a30e3d/900-8b103b/950-4e031b;yellow:50-fff9eb/100-fef0c8/200-fddd8b/300-fccb4f/400-fbbd23/500-f5af00/600-f1a200/700-e58e00/800-c87200/900-9c4f00/950-7a3700;green:50-edfcf5/100-d4f7e4/200-abedcd/300-78ddb3/400-3dd198/500-1bc58a/600-0eb47d/700-0d9c71/800-0f805e/900-0c644b/950-085441;blue:50-f0f8fe/100-deeefb/200-c4e2f8/300-9bd0f3/400-6db6ed/500-549ee7/600-4687dd/700-3778d2/800-2c5ca5/900-213e6e/950-192e4d
 
 export const theme = {
   borderColor: ({ theme }) => ({
@@ -21,10 +21,8 @@ export const theme = {
     black: colors.black,
     cyan: colors.cyan,
     fuschia: colors.fuschia,
-    green: colors.emerald,
     orange: colors.orange,
     white: colors.white,
-    yellow: colors.amber,
     primary: {
       50: '#ecebff',
       100: '#dedbff',
@@ -54,15 +52,15 @@ export const theme = {
     blue: {
       50: '#f0f8fe',
       100: '#deeefb',
-      200: '#c4e3f9',
-      300: '#9cd1f4',
+      200: '#c4e2f8',
+      300: '#9bd0f3',
       400: '#6db6ed',
       500: '#549ee7',
-      600: '#367dda',
-      700: '#2d69c8',
-      800: '#2b56a2',
-      900: '#274a81',
-      950: '#1c2e4f'
+      600: '#4687dd',
+      700: '#3778d2',
+      800: '#2c5ca5',
+      900: '#213e6e',
+      950: '#192e4d'
     },
     red: {
       50: '#fff1f3',
@@ -76,6 +74,32 @@ export const theme = {
       800: '#a30e3d',
       900: '#8b103b',
       950: '#4e031b'
+    },
+    yellow: {
+      50: '#fff9eb',
+      100: '#fef0c8',
+      200: '#fddd8b',
+      300: '#fccb4f',
+      400: '#fbbd23',
+      500: '#f5af00',
+      600: '#f1a200',
+      700: '#e58e00',
+      800: '#c87200',
+      900: '#9c4f00',
+      950: '#7a3700'
+    },
+    green: {
+      50: '#edfcf5',
+      100: '#d4f7e4',
+      200: '#abedcd',
+      300: '#78ddb3',
+      400: '#3dd198',
+      500: '#1bc58a',
+      600: '#0eb47d',
+      700: '#0d9c71',
+      800: '#0f805e',
+      900: '#0c644b',
+      950: '#085441'
     }
   },
   fontSize: {


### PR DESCRIPTION
Make slight adjustments to the yellow, green, and blue palettes (mainly in the 500-700 range as some of the hover/active states for colored buttons were a bit too harsh/jarring)