### PR TITLE
Move `backgroundImage` and `borderColor` under `extend`

### DIFF
--- a/theme.js
+++ b/theme.js
@@ -11,16 +11,10 @@ const spacing = [
 // https://uicolors.app/edit?sv1=primary:50-ecebff/100-dedbff/200-c7c2ff/300-a899ff/400-937aff/500-7e61ff/600-6a4ce1/700-5b33c7/800-3e238b/900-251452/950-11082b;slate:50-f4f4fb/100-e7e7f4/200-d9d9ed/300-c4c4e3/400-aeaed6/500-9692c4/600-8178b0/700-655b95/800-4b4276/900-332b5a/950-1d1641;red:50-fff1f3/100-ffe3e6/200-ffccd4/300-ffa1b1/400-ff708a/500-f93a63/600-e7174e/700-c30d41/800-a30e3d/900-8b103b/950-4e031b;yellow:50-fff9eb/100-fef0c8/200-fddd8b/300-fccb4f/400-fbbd23/500-f5af00/600-f1a200/700-e58e00/800-c87200/900-9c4f00/950-7a3700;green:50-edfcf5/100-d4f7e4/200-abedcd/300-78ddb3/400-3dd198/500-1bc58a/600-0eb47d/700-0d9c71/800-0f805e/900-0c644b/950-085441;blue:50-f0f8fe/100-deeefb/200-c4e2f8/300-9bd0f3/400-6db6ed/500-549ee7/600-4687dd/700-3778d2/800-2c5ca5/900-213e6e/950-192e4d
 
 module.exports = {
+  // ⚠️ CAUTION ⚠️ Any code placed directly under `theme` will REPLACE all
+  // built-in Tailwind utilities for that property. To add custom utilities
+  // while keeping the default ones, add them to the `extend` property instead
   theme: {
-    backgroundImage: ({ theme }) => ({
-      'gradient-radial-darker': `radial-gradient(circle at 70% 30%, ${theme('colors.primary.900')}, ${theme('colors.primary.950')});`,
-      'gradient-radial-dark': `radial-gradient(circle at 70% 30%, ${theme('colors.primary.800')}, ${theme('colors.primary.950')});`,
-      'gradient-radial-purple': `radial-gradient(circle at 70% 30%, ${theme('colors.primary.500')}, ${theme('colors.primary.800')});`
-    }),
-    borderColor: ({ theme }) => ({
-      ...theme('colors'),
-      DEFAULT: theme('colors.slate.100', 'currentColor'),
-    }),
     colors: {
       none: colors.none,
       inherit: colors.inherit,
@@ -125,7 +119,18 @@ module.exports = {
       '7xl': ['5rem', { lineHeight: '1.1' }], // 80px
       '8xl': ['6rem', { lineHeight: '1.1' }] // 96px
     },
+
+    // Add custom Tailwind utilities here ======================================
+
     extend: {
+      backgroundImage: ({ theme }) => ({
+        'gradient-radial-darker': `radial-gradient(circle at 80% 20%, ${theme('colors.primary.900')}, ${theme('colors.primary.950')});`,
+        'gradient-radial-dark': `radial-gradient(circle at 80% 20%, ${theme('colors.primary.800')}, ${theme('colors.primary.950')});`,
+        'gradient-radial-purple': `radial-gradient(circle at 80% 20%, ${theme('colors.primary.500')}, ${theme('colors.primary.800')});`
+      }),
+      borderColor: ({ theme }) => ({
+        DEFAULT: theme('colors.slate.100', 'currentColor'),
+      }),
       fontFamily: {
         sans: ['Inter', ...defaultTheme.fontFamily.sans],
         code: [
@@ -141,15 +146,10 @@ module.exports = {
         '65': '.65',
         '85': '.85'
       },
-      screens: {
-        '2xs': '375px',
-        xs: '414px'
-      },
+      screens: { '2xs': '375px', xs: '414px' },
       spacing: {
         ...Object.fromEntries(
-          spacing.map((num, index) => {
-            return [`${num}px`, `${num / 16}rem`]
-          })
+          spacing.map((num, index) => [`${num}px`, `${num / 16}rem`])
         )
       },
       transitionTimingFunction: {


### PR DESCRIPTION
Fixes a bug where default `bg-` utilities were broken on the website due to being overridden by the custom ones